### PR TITLE
Added 'FK property changed' convention and test.

### DIFF
--- a/EFCore.NamingConventions/Conventions/ForeignKeyPropertiesChangedConvention.cs
+++ b/EFCore.NamingConventions/Conventions/ForeignKeyPropertiesChangedConvention.cs
@@ -1,0 +1,22 @@
+﻿using EFCore.NamingConventions.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EFCore.NamingConventions.Conventions;
+
+public class ForeignKeyPropertiesChangedConvention(INameRewriter nameRewriter) : IForeignKeyPropertiesChangedConvention
+{
+    public void ProcessForeignKeyPropertiesChanged(
+        IConventionForeignKeyBuilder relationshipBuilder,
+        IReadOnlyList<IConventionProperty> oldDependentProperties,
+        IConventionKey oldPrincipalKey,
+        IConventionContext<IReadOnlyList<IConventionProperty>> context)
+    {
+        if (relationshipBuilder.Metadata.GetDefaultName() is { } constraintName)
+        {
+            relationshipBuilder.HasConstraintName(nameRewriter.RewriteName(constraintName));
+        }
+    }
+}

--- a/EFCore.NamingConventions/EFCore.NamingConventions.csproj
+++ b/EFCore.NamingConventions/EFCore.NamingConventions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
-    <VersionPrefix>8.0.0-rc.2</VersionPrefix>
+    <VersionPrefix>8.0.0-rc.3</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <PackageId>EntityFrameworkCore.NamingConventions</PackageId>

--- a/EFCore.NamingConventions/NamingConventionSetPlugin.cs
+++ b/EFCore.NamingConventions/NamingConventionSetPlugin.cs
@@ -34,6 +34,7 @@ public class NamingConventionSetPlugin(IDbContextOptions options) : IConventionS
         conventionSet.EntityTypeAnnotationChangedConventions.Add(new EntityTypeAnnotationChangedConvention(rewriter));
         conventionSet.PropertyAddedConventions.Add(new PropertyAddedConvention(rewriter));
         conventionSet.ForeignKeyOwnershipChangedConventions.Add(new ForeignKeyOwnershipChangedConvention(rewriter));
+        conventionSet.ForeignKeyPropertiesChangedConventions.Add(new ForeignKeyPropertiesChangedConvention(rewriter));
         conventionSet.KeyAddedConventions.Add(new KeyAddedConvention(rewriter));
         conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyAddedConvention(rewriter));
         conventionSet.IndexAddedConventions.Add(new IndexAddedConvention(rewriter));


### PR DESCRIPTION
Implementation of the **IForeignKeyPropertiesChangedConvention**'.

PS.:
The test implemented covers what triggered the issue for me.

EF core does not automatically maps properties without setters. https://github.com/dotnet/efcore/issues/10844#issuecomment-362338017

In case you define an ID without a setter, EF will map it as "Keyless" and add "temp" to the FK constraint names.

Once you define an ID manually, the constraints name are never corrected since **ForeignKeyPropertiesChangedConventions** is not implemented.

Fixes issues: https://github.com/efcore/EFCore.NamingConventions/issues/148, https://github.com/efcore/EFCore.NamingConventions/issues/198

Pre-existing PR: https://github.com/efcore/EFCore.NamingConventions/pull/149

![image](https://github.com/efcore/EFCore.NamingConventions/assets/29243277/4fad15d8-d080-4820-8f91-03a232257518)
